### PR TITLE
fix: version switcher redirects

### DIFF
--- a/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
+++ b/src/pydata_sphinx_theme/assets/scripts/pydata-sphinx-theme.js
@@ -293,9 +293,16 @@ function checkPageExistsAndRedirect(event) {
 
   fetch(tryUrl, { method: "HEAD" })
     .then(() => {
-      location.href = tryUrl;
-    }) // if the page exists, go there
+      if (head.ok) {
+        // if the page exists, go there
+        location.href = tryUrl;
+      } else {
+        // 404 or something; go to docs homepage instead
+        location.href = otherDocsHomepage;
+      }
+    })
     .catch((error) => {
+      // something went wrong, probably CORS restriction, fallback to other docs homepage
       location.href = otherDocsHomepage;
     });
 


### PR DESCRIPTION
The fetch().catch() doesn't fire if you get a 404.  You have to check that response.ok is true in the .then() bit.

This is a backport of Daniel McCloy's c610f9a7 change which is part of pydata-sphinx-theme>=0.14.0.  However, since sphinx-book-theme doesn't seem to support pydata-sphinx-theme>=0.14.0, we backported it.